### PR TITLE
fix(cache): Request scheme 'chrome-extension' is unsupported

### DIFF
--- a/js13kpwa/sw.js
+++ b/js13kpwa/sw.js
@@ -40,6 +40,13 @@ self.addEventListener('install', (e) => {
 
 // Fetching content using Service Worker
 self.addEventListener('fetch', (e) => {
+    // Cache http and https only, skip unsupported chrome-extension:// and file://...
+    if (!(
+       e.request.url.startsWith('http:') || e.request.url.startsWith('https:')
+    )) {
+        return; 
+    }
+
   e.respondWith((async () => {
     const r = await caches.match(e.request);
     console.log(`[Service Worker] Fetching resource: ${e.request.url}`);


### PR DESCRIPTION
Fix this error:
Uncaught (in promise) TypeError: Request scheme 'chrome-extension' is unsupported #1
