### PR TITLE
Make the JS button require JS to show.

### DIFF
--- a/a2hs/index.js
+++ b/a2hs/index.js
@@ -30,7 +30,7 @@ window.addEventListener('beforeinstallprompt', (e) => {
   // Stash the event so it can be triggered later.
   deferredPrompt = e;
   // Update UI to notify the user they can add to home screen
-  addBtn.style.display = 'inline-block';
+  addBtn.style.display = 'block';
 
   addBtn.addEventListener('click', () => {
     // hide our user interface that shows our A2HS button

--- a/a2hs/index.js
+++ b/a2hs/index.js
@@ -23,7 +23,6 @@ if ('serviceWorker' in navigator) {
 
 let deferredPrompt;
 const addBtn = document.querySelector('.add-button');
-addBtn.style.display = 'none';
 
 window.addEventListener('beforeinstallprompt', (e) => {
   // Prevent Chrome 67 and earlier from automatically showing the prompt
@@ -31,7 +30,7 @@ window.addEventListener('beforeinstallprompt', (e) => {
   // Stash the event so it can be triggered later.
   deferredPrompt = e;
   // Update UI to notify the user they can add to home screen
-  addBtn.style.display = 'block';
+  addBtn.style.display = 'inline-block';
 
   addBtn.addEventListener('click', () => {
     // hide our user interface that shows our A2HS button

--- a/a2hs/style.css
+++ b/a2hs/style.css
@@ -17,6 +17,7 @@ img {
   position: absolute;
   top: 1px;
   left: 1px;
+  display: none;
 }
 
 @media (orientation: landscape) {


### PR DESCRIPTION
The button was being shown, then hidden with JS, then shown again if the browser supports installs. As the button does nothing without JS, it should only be shown if the JS works.